### PR TITLE
Fix bug #76 - execute check for cursor in quickfix

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -283,7 +283,7 @@ function! s:AsyncRun_Job_CheckScroll()
 	elseif g:asyncrun_last == 1
 		let s:async_check_last = 1
 		let l:winnr = winnr()
-		noautocmd windo call s:AsyncRun_Job_Cursor()
+		noautocmd exec '' . l:winnr . 'windo call s:AsyncRun_Job_Cursor()'
 		noautocmd silent! exec ''.l:winnr.'wincmd w'
 		return s:async_check_last
 	elseif g:asyncrun_last == 2


### PR DESCRIPTION
Fix the bug "Cannot use visual selection when asyncrun is running" #76 by giving the windo command the right window number.