### PR TITLE
Fix bug #76 - execute check in quickfix window only

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -283,7 +283,7 @@ function! s:AsyncRun_Job_CheckScroll()
 	elseif g:asyncrun_last == 1
 		let s:async_check_last = 1
 		let l:winnr = winnr()
-		noautocmd windo call s:AsyncRun_Job_Cursor()
+		noautocmd exec '' . l:winnr . 'windo call s:AsyncRun_Job_Cursor()'
 		noautocmd silent! exec ''.l:winnr.'wincmd w'
 		return s:async_check_last
 	elseif g:asyncrun_last == 2

--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -283,8 +283,12 @@ function! s:AsyncRun_Job_CheckScroll()
 	elseif g:asyncrun_last == 1
 		let s:async_check_last = 1
 		let l:winnr = winnr()
-		noautocmd exec '' . l:winnr . 'windo call s:AsyncRun_Job_Cursor()'
-		noautocmd silent! exec ''.l:winnr.'wincmd w'
+		" Execute AsyncRun_Job_Cursor() in quickfix
+		let l:quickfixwinnr = bufwinnr("[Quickfix List]")
+		if l:quickfixwinnr != -1  " -1 mean the buffer has no window or do not exists
+			noautocmd exec '' . l:quickfixwinnr . 'windo call s:AsyncRun_Job_Cursor()'
+		endif
+                noautocmd silent! exec ''.l:winnr.'wincmd w'
 		return s:async_check_last
 	elseif g:asyncrun_last == 2
 		return 1


### PR DESCRIPTION
(Typo in commit message, it's not for bug #73 but for bug #76).

Better correction which will always execute the windo command in the quickfix window if it is displayed. 