### PR TITLE
fix when async job finishes before AsyncRun_Job_Start() sets async_state=1

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -652,7 +652,7 @@ function! s:AsyncRun_Job_Start(cmd)
 		let s:async_start = float2nr(reltimefloat(reltime()))
 		let l:name = 'g:AsyncRun_Job_OnTimer'
 		let s:async_timer = timer_start(100, l:name, {'repeat':-1})
-		let s:async_state = 1
+		let s:async_state = or(s:async_state, 1)
 		let g:asyncrun_status = "running"
 		let s:async_info.post = s:async_info.postsave
 		let s:async_info.auto = s:async_info.autosave


### PR DESCRIPTION
Fixes #25 .
This issue is that sometimes -when system() is busy for instance- the execution can go like that:
  1- AsyncRun_Job_OnExit()   finishes (s:async_state=2)
  2- AsyncRun_Job_OnClose()  finishes (s:async_state=6)
  3- AsyncRun_Job_Start()    let s:async_state = 1

Hence, s:async_state is never equal to 7 and AsyncRun_Job_OnFinish() is never called
by AsyncRun_Job_OnTimer().

Could you please merge this PR ?
Thanks in advance !