### PR TITLE
Add -bar to AsyncStop to allow for chaining

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -1317,7 +1317,7 @@ endfunc
 command! -bang -nargs=+ -range=0 -complete=file AsyncRun 
 	\ call asyncrun#run('<bang>', '', <q-args>, <count>, <line1>, <line2>)
 
-command! -bang -nargs=0 AsyncStop call asyncrun#stop('<bang>')
+command! -bar -bang -nargs=0 AsyncStop call asyncrun#stop('<bang>')
 
 
 


### PR DESCRIPTION
This means you can do `:AsyncStop | AsyncRun [cmd]` all in one. 

I'm not too familiar with the downsides, but since `:AsyncStop` doesn't take args, it should be fine.