### PR TITLE
adding $VIM_HOME

### DIFF
--- a/doc/asyncrun.txt
+++ b/doc/asyncrun.txt
@@ -227,6 +227,7 @@ Environment variables are set before executing:
   $VIM_COLUMNS   - How many columns in vim's screen
   $VIM_LINES     - How many lines in vim's screen
   $VIM_SVRNAME   - Value of v:servername for +clientserver usage
+  $VIM_HOME      - First directory in runtimepath (eg. ~/.vim for linux)
 <
 These environment variables wrapped by '$(...)' (eg. '$(VIM_FILENAME)') will
 also be expanded in the parameters. Macro '$(VIM_ROOT)' and '<root>' (new in

--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -1187,6 +1187,7 @@ function! asyncrun#run(bang, opts, args, ...)
 	let l:macros['VIM_LINES'] = ''.&lines
 	let l:macros['VIM_GUI'] = has('gui_running')? 1 : 0
 	let l:macros['VIM_ROOT'] = asyncrun#get_root('%')
+    let l:macros['VIM_HOME'] = expand(split(&rtp, ',')[0])
 	let l:macros['<cwd>'] = l:macros['VIM_CWD']
 	let l:macros['<root>'] = l:macros['VIM_ROOT']
 	let l:retval = ''


### PR DESCRIPTION
The $VIM_HOME environment variable takes the value of the first directory in the runtime path (~/.vim in linux etc). This is useful for referencing  files that one may want to carry with vim or neovim across distributions (eg. css style sheet for pandoc).