### PR TITLE
Document how to fix broken multi-line errorformat

### DIFF
--- a/doc/asyncrun.txt
+++ b/doc/asyncrun.txt
@@ -17,6 +17,7 @@ Contents ~
    6. Git push                                              |asyncrun-git-push|
    7. Setup '<F7>' to compile file                                         |F7|
    8. Run a python script                          |asyncrun-run-python-script|
+   9. Reformat output on completion                   |asyncrun-multi-line-efm|
  7. Manual                                                    |asyncrun-manual|
    1. AsyncRun - Run shell command                 |asyncrun-run-shell-command|
    2. AsyncStop - Stop the running job    |asyncrun-asyncstop-stop-running-job|
@@ -181,6 +182,19 @@ New option '-raw' will display the raw output (without matching to
 errorformat), you need the latest AsyncRun (after 1.3.13) to use this option.
 Remember to put 'let $PYTHONUNBUFFERED=1' in your '.vimrc' to disable python
 stdout buffering, see here [3].
+
+-------------------------------------------------------------------------------
+                                                      *asyncrun-multi-line-efm*
+Reformat output on completion ~
+>
+  augroup local-asyncrun
+    au!
+    au User AsyncRunStop copen | wincmd p
+  augroup END
+<
+Vim may parse |errorformat-multi-line| incorrectly (using %A, %C, %Z) and omit
+or duplicate output. You can ask vim to re-parse quickfix content with
+|copen|. This autocmd will automatically re-parse quickfix on job completion.
 
 ===============================================================================
                                                               *asyncrun-manual*


### PR DESCRIPTION
Fixes #179.
See also vim/vim#5735.

:copen refreshes the quickfix, so doing it on completion ensures the
quickfix output is processed as a whole and multiline output is
displayed correctly.

Since this would open the quickfix if the user closed it, I assume we wouldn't want it to be part of core asyncrun behaviour.