### PR TITLE
fix: use qf id to prevent interleaving output

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -240,6 +240,7 @@
 - g:asyncrun_timer - 每 100ms 处理多少条消息，默认为 25。
 - g:asyncrun_wrapper - 命令前缀，默认为空，比如可以设置成 `nice`。
 - g:asyncrun_stdin - 设置成非零的话，允许 stdin，比如 cmake 在 windows 下要求 stdin 为打开状态。
+- g:asyncrun_qfid - 使用 quickfix id 来防止附加到 quickfix 列表的并发插件的交错输出。
 
 更多配置内容，见 **[这里](https://github.com/skywind3000/asyncrun.vim/wiki/Options)**.
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ parameters:
 - g:asyncrun_timer - how many messages should be inserted into quickfix every 100ms interval.
 - g:asyncrun_wrapper - enable to setup a command prefix.
 - g:asyncrun_stdin - non-zero to enable stdin (useful for cmake on windows).
+- g:asyncrun_qfid - use quickfix id to prevent interleaving output of concurrent plugins appending to the quickfix list.
 
 For more information of above options, please visit **[option details](https://github.com/skywind3000/asyncrun.vim/wiki/Options)**.
 

--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -133,8 +133,8 @@ let g:asyncrun_mode = get(g:, 'asyncrun_mode', 0)
 " Use quickfix-ID to allow concurrent use of quickfix list and not
 " interleave streamed output of a running command with output from
 " other plugins
-if !exists('g:asyncrun_qf_id_available')
-	let g:asyncrun_qf_id_available = has('patch-8.0.1023') || has('nvim-0.6.1')
+if !exists('g:asyncrun_qf_id')
+	let g:asyncrun_qf_id = has('patch-8.0.1023') || has('nvim-0.6.1')
 endif
 
 " command hook
@@ -877,7 +877,7 @@ function! s:AsyncRun_Job_Start(cmd)
 				call setqflist([], ' ', l:title)
 			endif
 		endif
-		if g:asyncrun_qf_id_available == 1
+		if g:asyncrun_qf_id == 1
 			let s:qf_id = getqflist({'id':0}).id
 		endif
 		if !s:async_info.strip


### PR DESCRIPTION
Fixes #73

This is RFC. Since the id functionality for vim only landed in 8.0.1023 and nvim v0.6.1, there should probably be some checks added for this functionality? Or should it silently fail as the dictionary key is simply ignored?

One caveat to this (probably more important to add to documentation than to fix it) is that when there are more quickfix lists than 10, the least recently updated quickfix list is freed. If the output of the command is frequent enough (more frequent than we add quickfix lists) this is not an issue. If there is a long running command with no output, though, the quickfix list will silently be freed and the output of the command effectively goes into void.