### PR TITLE
Fix missing local variable `M` in toggleterm.lua 

### DIFF
--- a/lua/asyncrun/toggleterm.lua
+++ b/lua/asyncrun/toggleterm.lua
@@ -1,5 +1,6 @@
 local terminal = require("toggleterm.terminal").Terminal
 local config = require("toggleterm.config")
+local M = {}
 
 function M.reset()
   if M._asyncrun_term ~= nil then


### PR DESCRIPTION
cannot return local variable `M` without declaring it first.