### PR TITLE
fix: tab page restoration when `focus=0` & `reuse=1`

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -1481,10 +1481,10 @@ function! s:start_in_terminal(opts)
 		if hr >= 0
 			if focus == 0
 				exec has('nvim')? 'stopinsert' : ''
-				if pos ==# 'TAB'
-					exec 'tabnext'
-				else
-					exec 'tabprevious'
+				let last_tid = tabpagenr('#')
+				if last_tid > 0
+					" Go to the last accessed tab page.
+					exec 'tabnext' last_tid
 				endif
 			endif
 		endif


### PR DESCRIPTION
Fix: #248

I use `tabpagenr('#')` to get the last accessed tab page number and then jump to it.