### PR TITLE
add AsyncReset

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -2061,6 +2061,16 @@ function! asyncrun#stop(bang)
 endfunc
 
 
+"----------------------------------------------------------------------
+" asyncrun - reset
+"----------------------------------------------------------------------
+function! asyncrun#reset()
+	let s:async_state = 0
+	if exists('s:async_job')
+		let s:async_job = 0
+	endif
+endfunc
+
 
 "----------------------------------------------------------------------
 " asyncrun - status
@@ -2086,6 +2096,8 @@ command! -bang -nargs=+ -range=0 -complete=file AsyncRun
 		\ call asyncrun#run('<bang>', '', <q-args>, <count>, <line1>, <line2>)
 
 command! -bar -bang -nargs=0 AsyncStop call asyncrun#stop('<bang>')
+
+command! -nargs=0 AsyncReset call asyncrun#reset()
 
 
 "----------------------------------------------------------------------


### PR DESCRIPTION
Awesome plugin!
We all dislike to run terrible code, but there will still be some case like #204 and we have to restart (neo)vim instance.
So I think it's great to have an `AsyncReset` command to reset internal state forcely and ignore the crashed process directly. 

@skywind3000  Are you willing to merge this PR to provide a reset command, which may have some corner negetive effect though (e.g. The crashed progress is allocating memory crazily).

Or could you give some comments on the function `asyncrun#reset` below, which just reset two script variable forcely?

```vim
function! asyncrun#reset()
	let s:async_state = 0
	if exists('s:async_job')
		let s:async_job = 0
	endif
endfunc
```