### PR TITLE
fix: Use shellcmd completion for AsyncRun

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -2120,7 +2120,7 @@ endfunc
 "----------------------------------------------------------------------
 " Commands
 "----------------------------------------------------------------------
-command! -bang -nargs=+ -range=0 -complete=file AsyncRun
+command! -bang -nargs=+ -range=0 -complete=shellcmd AsyncRun
 		\ call asyncrun#run('<bang>', '', <q-args>, <count>, <line1>, <line2>)
 
 command! -bar -bang -nargs=0 AsyncStop call asyncrun#stop('<bang>')


### PR DESCRIPTION
The semantics of `AsyncRun <cmd>` is to run a shell cmd through the vim command line,
so command completion should be `shellcmd`, not `file`.