### PR TITLE
Support powershell with nvim

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -761,7 +761,7 @@ function! s:AsyncRun_Job_Start(cmd)
 			if s:async_nvim == 0
 				let l:args += [l:tmp]
 			else
-				let l:args = s:shellescape(l:tmp)
+				let l:args += [s:shellescape(l:tmp)]
 			endif
 		endif
 	elseif type(a:cmd) == 3

--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -173,6 +173,9 @@ let g:asyncrun_shell = get(g:, 'asyncrun_shell', '')
 " specify shell cmd flag rather than &shellcmdflag
 let g:asyncrun_shellflag = get(g:, 'asyncrun_shellflag', '')
 
+" Using nvim with windows and powershell
+let g:asyncrun_using_nvim_win_powershell = get(g:, 'asyncrun_using_nvim_win_powershell', 0)
+
 " external runners for '-mode=terminal'
 let g:asyncrun_runner = get(g:, 'asyncrun_runner', {})
 
@@ -761,7 +764,11 @@ function! s:AsyncRun_Job_Start(cmd)
 			if s:async_nvim == 0
 				let l:args += [l:tmp]
 			else
-				let l:args += [s:shellescape(l:tmp)]
+				if g:asyncrun_using_nvim_win_powershell == 0
+					let l:args = s:shellescape(l:tmp)
+				else
+					let l:args = l:tmp
+				endif
 			endif
 		endif
 	elseif type(a:cmd) == 3


### PR DESCRIPTION
The purpose of this pull request is to allow changing the shell on windows with nvim.

I am using nvim with windows and my nvim shell is powershell,

I have not to integrated this pluggin with powershell, 

However, I could integrate this with cmd by setting

```
let g:asyncrun_shellflag = '/C'

let g:asyncrun_shell= 'cmd.exe'
```

And perfoming this code change

shellescape is overwriting s:args meaning the custom shell and flags (e.g. ["cmd.exe", "/C"]) are discarded

# Edit
Pull request is now to support powershell as the default shell
