### PR TITLE
Log "with code 0" when s:async_code == 0

### DIFF
--- a/plugin/asyncrun.vim
+++ b/plugin/asyncrun.vim
@@ -598,7 +598,7 @@ function! s:AsyncRun_Job_OnFinish()
 	let l:last = l:current - s:async_start
 	let l:check = s:AsyncRun_Job_CheckScroll()
 	if s:async_code == 0
-		let l:text = "[Finished in ".l:last." seconds]"
+		let l:text = "[Finished in ".l:last." seconds with code 0]"
 		if !s:async_info.strip
 			call s:AppendText([l:text], 1)
 		endif


### PR DESCRIPTION
我在用`Asyncrun make`的时候, quickfix滚动到最后, 但是我经常无法反应过来这到底是有错误还是没有错误, 因为没有错误的时候, 是没有 "with code ?" 的, 所以我把日志统一了, 这样我只要看最后那一行是不是有 0 字样, 就知道是否执行成功了.

当然, 最有辨识度的方法就是这行日志在非0退出码的时候以错误颜色显示, 但是quick fix貌似没啥好办法做自己的语法高亮了 (可以考虑用matchadd()的方式?)